### PR TITLE
Add GitHub Action for Maven build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: '1.8'
+        java-version: '11'
         distribution: 'temurin'
 
     - name: Checkout repository

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,29 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v2
+      with:
+        java-version: '1.8'
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Run tests
+      run: mvn test

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,6 +18,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '1.8'
+        distribution: 'temurin'
 
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Trie这个术语来自于retrieval。trie的发明者Edward Fredkin把它读作/
 - 练习 4 - 使用 AI编码助手 聊天调试和修复代码
 - 练习 5 - 使用 AI编码助手 生成单元测试代码
 
+## GitHub Actions 和 CI/CD 管道
+
+在本项目中，我们使用 GitHub Actions 来设置 CI/CD 管道。GitHub Actions 配置文件位于 `.github/workflows/maven.yml`。
+
+通过 GitHub Actions，我们可以自动化以下任务：
+- 设置 Java 环境
+- 检出代码库
+- 运行 Maven 命令
+- 运行测试并报告结果
+
 ## 联系我们
 
 如果您在使用 **AI编码助手** 的过程中遇到任何问题，或者您有任何建议和反馈，请随时联系我们。您可以通过以下方式联系我们：


### PR DESCRIPTION
Fixes #1

Add GitHub Actions configuration for CI/CD pipeline.

* **README.md**
  - Add a section about GitHub Actions and CI/CD pipeline in Chinese.
  - Mention the location of the GitHub Actions configuration file.

* **.github/workflows/maven.yml**
  - Create a GitHub Actions configuration file for Maven build.
  - Include steps for setting up Java, checking out the repository, and running Maven commands.
  - Add steps for running tests and reporting results.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ups216/auto-suggest-java-demo/pull/3?shareId=738ebec7-16e7-4563-b15a-8571e417d6ea).