### PR TITLE
Add search function

### DIFF
--- a/src/main/java/org/example/leansoftx/Main.java
+++ b/src/main/java/org/example/leansoftx/Main.java
@@ -20,7 +20,7 @@ public class Main {
     public static void main(String[] args) {
 
         dictionary.printTrieStructure();
-        //searchWord();
+        searchWord();
         //prefixAutoComplete();
         //deleteWord();
         //getSpellingSuggestions();
@@ -44,12 +44,9 @@ public class Main {
             if (input.isEmpty()) {
                 break;
             }
-            /*
             if (dictionary.search(input)) {
                 System.out.println("Found \"" + input + "\" in dictionary");
-            }
-            */
-            else {
+            } else {
                 System.out.println("Did not find \"" + input + "\" in dictionary");
             }
         }

--- a/src/main/java/org/example/leansoftx/Trie.java
+++ b/src/main/java/org/example/leansoftx/Trie.java
@@ -24,6 +24,17 @@ public class Trie {
         return true;
     }
 
+    public boolean search(String word) {
+        TrieNode current = root;
+        for (char c : word.toCharArray()) {
+            if (!current.hasChild(c)) {
+                return false;
+            }
+            current = current.children.get(c);
+        }
+        return current.isEndOfWord;
+    }
+
     public List<String> autoSuggest(String prefix) {
         TrieNode currentNode = root;
         for (char c : prefix.toCharArray()) {

--- a/src/test/java/org/example/leansoftx/TrieTests.java
+++ b/src/test/java/org/example/leansoftx/TrieTests.java
@@ -5,4 +5,43 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TrieTests {
+
+    @Test
+    public void testInsertAndSearch() {
+        Trie trie = new Trie();
+        assertTrue(trie.insert("hello"));
+        assertTrue(trie.search("hello"));
+        assertFalse(trie.search("hell"));
+        assertFalse(trie.search("helloo"));
+        assertFalse(trie.search("world"));
+    }
+
+    @Test
+    public void testInsertDuplicate() {
+        Trie trie = new Trie();
+        assertTrue(trie.insert("hello"));
+        assertFalse(trie.insert("hello"));
+    }
+
+    @Test
+    public void testSearchEmptyTrie() {
+        Trie trie = new Trie();
+        assertFalse(trie.search("hello"));
+    }
+
+    @Test
+    public void testSearchPrefix() {
+        Trie trie = new Trie();
+        trie.insert("hello");
+        assertFalse(trie.search("hell"));
+    }
+
+    @Test
+    public void testSearchWordWithCommonPrefix() {
+        Trie trie = new Trie();
+        trie.insert("hello");
+        trie.insert("hell");
+        assertTrue(trie.search("hello"));
+        assertTrue(trie.search("hell"));
+    }
 }


### PR DESCRIPTION
Fixes #2

Add `search(String word)` method to `Trie` class and update `Main` class to use it.

* **Trie.java**
  - Add `search(String word)` method to check if a word exists in the trie.
  - Implement the `search(String word)` method to traverse the trie and return a boolean indicating if the word exists.

* **Main.java**
  - Uncomment the `searchWord()` method.
  - Update the `searchWord()` method to use the `search(String word)` method from the `Trie` class to search for words.

* **TrieTests.java**
  - Add unit tests for the `search(String word)` method in the `Trie` class.
  - Test cases include inserting and searching for words, searching in an empty trie, searching for prefixes, and searching for words with common prefixes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ups216/auto-suggest-java-demo/pull/4?shareId=c182baa4-8bdb-4fed-b193-f59fa87545ac).