### PR TITLE
Add GitHub Actions workflow for CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v2
+      with:
+        java-version: 1.8
+
+    - name: Install dependencies
+      run: mvn install
+
+    - name: Run tests
+      run: mvn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: 1.8
+        distribution: 'adopt'
 
     - name: Install dependencies
       run: mvn install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v2
 
-    - name: Set up JDK 1.8
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        java-version: 17
         distribution: 'adopt'
 
     - name: Install dependencies

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="azul-1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="azul-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -67,3 +67,7 @@ Trie这个术语来自于retrieval。trie的发明者Edward Fredkin把它读作/
 - 网址 https://leansoftx.com
 - 电子邮件 info@leansoftx.com
 - 微信公众号 DevOps
+
+## CI/CD Pipeline
+
+This project uses GitHub Actions for continuous integration and continuous deployment (CI/CD). The GitHub Actions workflow is defined in the `.github/workflows/ci.yml` file. The workflow is triggered on `push` and `pull_request` events and includes steps to check out the repository, set up JDK 1.8, and run `mvn install` and `mvn test`.

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Fixes #1

Add GitHub Actions workflow for CI/CD pipeline.

* **README.md**
  - Add a new section "## CI/CD Pipeline" describing the purpose of the GitHub Actions workflow.
  - Mention the location of the workflow file and the events that trigger the workflow.

* **.github/workflows/ci.yml**
  - Add a new GitHub Actions workflow file named `ci.yml`.
  - Define the workflow to run on `push` and `pull_request` events for the `main` branch.
  - Set up a job named `build` that runs on `ubuntu-latest`.
  - Add steps to check out the repository, set up JDK 1.8, and run `mvn install` and `mvn test`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ups216/auto-suggest-java-demo/pull/2?shareId=72ef3d5e-74f0-48be-845d-aab8d3196b77).